### PR TITLE
Restore view when keyboard hides

### DIFF
--- a/KeyboardHiding/ViewController.swift
+++ b/KeyboardHiding/ViewController.swift
@@ -18,6 +18,14 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        let tapGesture: UITapGestureRecognizer = UITapGestureRecognizer(target: self, action: "hideKeyboard")
+        
+        // prevents the scroll view from swallowing up the touch event of child buttons
+        tapGesture.cancelsTouchesInView = false
+        
+        scrollView.addGestureRecognizer(tapGesture)
+        
     }
     
     override func viewWillAppear(animated: Bool) {
@@ -37,12 +45,14 @@ class ViewController: UIViewController {
         
     }
 
-    // Not currently functioning properly.
+    /*  Touches can't be used on a ScrollView, instead trigger gestures.
+    
     override func touchesEnded(touches: NSSet!, withEvent event: UIEvent!) {
         self.scrollView.endEditing(true)
         println("scrollView was touched.")
         
     }
+    */
 
     //MARK: Keyboard Avoidance
     func registerForKeyboardNotifications() -> Void {
@@ -73,9 +83,19 @@ class ViewController: UIViewController {
         }
     }
     
+    /* Function was replaced with hideKeyboard().
+    
     func keyboardWillBeHidden(notification: NSNotification) {
         self.scrollView.setContentOffset(CGPointZero, animated: true)
         
+    }
+    
+    */
+    
+    func hideKeyboard() {
+        username.resignFirstResponder()   //FirstResponder's must be resigned for hiding keyboard.
+        password.resignFirstResponder()
+        self.scrollView.setContentOffset(CGPointZero, animated: true)
     }
 
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 SwiftKeyboardHiding
 ===================
 
+UPDATE 13/01/2015 : Restore view when keyboard is hidden by omardlhz.
+
+
 Swift implementation of the UITextField keyboard hiding tutorial shown on [iOS-Blog](http://ios-blog.co.uk/tutorials/how-to-make-uitextfield-move-up-when-keyboard-is-present/) by [Vasilica Costescu](https://twitter.com/Vasy_1st/). 
 
 ![in-action](http://fat.gfycat.com/ImperfectCompleteJackrabbit.gif)


### PR DESCRIPTION
Fixed the problem that didn’t allow to hide the keyboard when the
textfield is not pressed. ScrollView's can’t trigger touches (they’re a
property of UIView), gestures where used instead.
